### PR TITLE
Support Multiple Client Certificats

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,30 @@ Save to a file and just run it with the xml file as argument
 
 BA provides a often updated Position description databae ("VAM" Berufe). The Gem can help to download it:
 
-```
+```ruby
 connection.misc.each do |link|
   target = "vendor/ba/#{link.href}"
   next if File.exist?(target)
   response = link.click
   File.open(target, "wb+") { |f| f.write(response.body) }
 end
+```
+
+### Usage with multiple client certificats
+
+Since September 2022, users with multiple client certificats issued to the same email address need to provide their respective partner ID when using the API.
+For user with only one certificat issued to their email address, providing the partner ID is optional.
+
+The partner ID can be provided as an optional keyword argument to the `upload`, `error_files` and `misc` methods:
+
+```ruby
+require 'ba_upload'
+connection = BaUpload.open_connection(file_path: 'config/Zertifikat-1XXXX.p12', passphrase: 'YOURPASSPHRASE')
+
+connection.upload(file: 'your_file_path', partner_id: 'P000XXXXXX')
+connection.error_files(partner_id: 'P000XXXXXX')
+connection.misc(partner_id: 'P000XXXXXX')
+
 ```
 
 ## License

--- a/lib/ba_upload/connection.rb
+++ b/lib/ba_upload/connection.rb
@@ -14,29 +14,40 @@ module BaUpload
       @m.cert = @cert.path
     end
 
-    def upload(file: nil)
-      m.get 'https://hrbaxml.arbeitsagentur.de/in/'
+    def upload(file: nil, partner_id: nil)
+      url = base_url(partner_id) + "in/"
+      m.get url
       form = m.page.forms.first
       form.file_uploads.first.file_name = file
       form.submit
     end
 
-    def error_files
-      m.get 'https://hrbaxml.arbeitsagentur.de/'
+    def error_files(partner_id: nil)
+      url = base_url(partner_id)
+      m.get url
       links = m.page.links_with(text: /ESP|ESV/)
       links.map do |link|
         ErrorFile.new(link)
       end
     end
 
-    def misc
-      m.get 'https://hrbaxml.arbeitsagentur.de/'
+    def misc(partner_id: nil)
+      url = base_url(partner_id)
+      m.get url
       m.page.links_with(text: /sonstiges/).first.click
       m.page.links.reject { |i| i.href[/^\?|mailto:/] || i.href == '/' }
     end
 
     def shutdown
       m.shutdown
+    end
+
+    private
+
+    def base_url(partner_id)
+      url = "https://hrbaxml.arbeitsagentur.de/"
+      url += "daten/#{partner_id}/" unless partner_id.nil?
+      url
     end
   end
 end


### PR DESCRIPTION
Hi there!

The Bundesagentur API recently changed for users having multiple certificates issued to the same email address. Here is a suggestion on how to handle that change 🙂